### PR TITLE
Pull down timestamped version of the CDC json file

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 bs4 = "*"
+requests = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3a5ea1c60f96b64393da694732a4f37d56cd8fde40af25e9a9ef6bcecf54c3ac"
+            "sha256": "124b7ff3bc9cb315c8b3e998fe92cbacfe4e51442fd53ea6592191a8a9d4a22e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,13 +31,52 @@
             "index": "pypi",
             "version": "==0.0.1"
         },
+        "certifi": {
+            "hashes": [
+                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
+                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+            ],
+            "version": "==2021.5.30"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1",
+                "sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==2.0.3"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
+                "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==3.2"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+            ],
+            "index": "pypi",
+            "version": "==2.26.0"
+        },
         "soupsieve": {
             "hashes": [
                 "sha256:052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc",
                 "sha256:c2c1c2d44f158cdbddab7824a9af8c4f83c76b1e23e049479aa432feb6c4c23b"
             ],
-            "markers": "python_version >= '3.0'",
+            "markers": "python_version >= '3'",
             "version": "==2.2.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.6"
         }
     },
     "develop": {}

--- a/acquire-data.py
+++ b/acquire-data.py
@@ -1,0 +1,41 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import requests
+import json
+import datetime
+import os
+import logging
+
+logger = logging.getLogger("root")
+logging.basicConfig(
+    format="\033[1;36m%(levelname)s: %(filename)s (def %(funcName)s %(lineno)s): \033[1;37m %(message)s",
+    level=logging.DEBUG
+)
+
+"""
+This script is the first step in the process
+to pull down a copy of the county-level json
+used to power the CDC's Covid-19 dashboard
+"""
+
+timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S")
+
+dir_current = os.path.dirname(os.path.realpath(__file__))
+
+dir_json = "daily-json"
+
+file_output = '{0}-cdc-daily-county.json'.format(timestamp)
+
+file_saved = os.path.join(dir_current, dir_json, file_output)
+
+target_url = "https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=integrated_county_latest_external_data"
+
+response = requests.get(target_url)
+
+data = json.loads(response.text)
+
+with open(file_saved, 'w', encoding='utf-8') as f:
+    json.dump(data, f, ensure_ascii=False, indent=4)
+
+logger.debug('File saved to {0}'.format(file_saved))


### PR DESCRIPTION
Adds `acquire-data.py` which will pull down a timestamped version of the CDC json file and store it in a dedicated directory. It also adds the requests library as a python dependency, though given more time I could have/should have made it work with the standard library.